### PR TITLE
fix: fix CVE-2026-3203 for wireshark

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wireshark (4.4.13-0+deb13u1deepin1) unstable; urgency=medium
+
+  * Fix CVE-2026-3203
+    - RF4CE Profile dissector crash
+    - Upstream fix: https://gitlab.com/wireshark/wireshark/-/commit/d487e0e
+
+ -- lichenggang <lichenggang@uniontech.com>  Wed, 22 Apr 2026 18:18:25 +0800
+
 wireshark (4.4.13-0+deb13u1) trixie-security; urgency=medium
 
   * Team upload.

--- a/debian/patches/CVE-2026-3203.patch
+++ b/debian/patches/CVE-2026-3203.patch
@@ -1,0 +1,37 @@
+From d487e0e07b15d80cf1521d3eed30f4114a38bf39 Mon Sep 17 00:00:00 2001
+From: John Thacker <johnthacker@gmail.com>
+Date: Sat, 7 Feb 2026 02:51:04 +0000
+Subject: [PATCH] RF4CE: Check that the input data is long enough
+
+Prevent illegal memory access.
+
+Fix: #21009
+
+AI-Assisted: no
+
+
+(cherry picked from commit 17215397c1a5fbb2ef8764b3ec29ec45cde9c153)
+
+Co-authored-by: John Thacker <johnthacker@gmail.com>
+---
+ epan/dissectors/packet-rf4ce-secur.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/epan/dissectors/packet-rf4ce-secur.c b/epan/dissectors/packet-rf4ce-secur.c
+index 9538dbc..c347ce5 100644
+--- a/epan/dissectors/packet-rf4ce-secur.c
++++ b/epan/dissectors/packet-rf4ce-secur.c
+@@ -614,6 +614,10 @@ bool decrypt_data(
+         return false;
+     }
+ 
++    if (*len < payload_offset + RF4CE_CCM_M) {
++        return false;
++    }
++
+     while (idx < RF4CE_NWK_KEY_STORAGE_SIZE)
+     {
+         if (nwk_key_storage[idx].is_used)
+-- 
+2.51.0
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 09_idl2wrs.patch
 0004-Use-packaged-JS-and-CSS-resources-instead-of-pulling.patch
 0001-wsutil-Restore-removed-ws_base32_decode.patch
+CVE-2026-3203.patch


### PR DESCRIPTION
Backport upstream security fix for CVE-2026-3203 to wireshark 4.4.13:
- CVE-2026-3203: RF4CE Profile dissector crash Upstream fix: https://gitlab.com/wireshark/wireshark/-/commit/d487e0e RF4CE: Check that the input data is long enough

Note: CVE-2026-3201 (USB HID dissector memory exhaustion) is already fixed in the current 4.4.13-0+deb13u1 source.

Log: Backport upstream fix for CVE-2026-3203 RF4CE dissector crash

Influence:
1. Test wireshark RF4CE dissector with malformed packets
2. Verify no crash when dissecting short RF4CE security frames
3. Ensure no regression in other protocol dissectors

fix: 修复 wireshark CVE-2026-3203 漏洞

为 wireshark 4.4.13 回移植 CVE-2026-3203 上游安全修复：
- CVE-2026-3203: RF4CE Profile 解析器崩溃 上游修复: https://gitlab.com/wireshark/wireshark/-/commit/d487e0e RF4CE: 检查输入数据长度是否足够

注意: CVE-2026-3201 (USB HID 解析器内存耗尽) 已在当前
4.4.13-0+deb13u1 源码中修复。

Log: 回移植 CVE-2026-3203 RF4CE 解析器崩溃修复

Influence:
1. 测试 wireshark RF4CE 解析器处理异常包
2. 验证解析短 RF4CE 安全帧时不会崩溃
3. 确保其他协议解析器无回归

repo: wireshark #master